### PR TITLE
Add Libultra 9801 patch

### DIFF
--- a/include/PR/gbi.h
+++ b/include/PR/gbi.h
@@ -1,4 +1,3 @@
-
 /**************************************************************************
  *									  *
  *		 Copyright (C) 1994, Silicon Graphics, Inc.		  *
@@ -12,8 +11,8 @@
  **************************************************************************/
 /**************************************************************************
  *
- *  $Revision: 1.128 $
- *  $Date: 1997/11/26 00:30:51 $
+ *  $Revision: 1.134 $
+ *  $Date: 1998/04/15 23:40:18 $
  *  $Source: /hosts/liberte/disk6/Master/cvsmdev2/PR/include/gbi.h,v $
  *
  **************************************************************************/
@@ -86,7 +85,10 @@
  *
  */
 
-#ifdef   F3DEX_GBI_2
+#ifdef    F3DEX_GBI_2
+# ifndef  F3DEX_GBI
+#  define F3DEX_GBI
+# endif
 #define	G_NOOP			0x00
 #define	G_RDPHALF_2		0xf1
 #define	G_SETOTHERMODE_H	0xe3
@@ -102,7 +104,10 @@
 #define G_GEOMETRYMODE		0xd9
 #define	G_POPMTX		0xd8
 #define	G_TEXTURE		0xd7
-#define	G_SUBMODULE		0xd6
+#define	G_DMA_IO		0xd6
+#define	G_SPECIAL_1		0xd5
+#define	G_SPECIAL_2		0xd4
+#define	G_SPECIAL_3		0xd3
 
 #define	G_VTX			0x01
 #define	G_MODIFYVTX		0x02
@@ -110,7 +115,8 @@
 #define	G_BRANCH_Z		0x04
 #define	G_TRI1			0x05
 #define G_TRI2			0x06
-#define G_LINE3D		0x07
+#define G_QUAD			0x07
+#define G_LINE3D		0x08
 #else	/* F3DEX_GBI_2 */
 
 /* DMA commands: */
@@ -288,7 +294,7 @@
 /*
  * G_MTX: parameter flags
  */
-#ifdef	F3DEX_GBI_2x
+#ifdef	F3DEX_GBI_2
 # define G_MTX_MODELVIEW	0x00	/* matrix types */
 # define G_MTX_PROJECTION	0x04
 # define G_MTX_MUL		0x00	/* concat or load */
@@ -330,13 +336,21 @@
  *
  */
 #define G_ZBUFFER		0x00000001
-#define G_TEXTURE_ENABLE	0x00000002	/* Microcode use only */
 #define G_SHADE			0x00000004	/* enable Gouraud interp */
 /* rest of low byte reserved for setup ucode */
-#define G_SHADING_SMOOTH	0x00000200	/* flat or smooth shaded */
-#define G_CULL_FRONT		0x00001000
-#define G_CULL_BACK		0x00002000
-#define G_CULL_BOTH		0x00003000	/* To make code cleaner */
+#ifdef	F3DEX_GBI_2
+# define G_TEXTURE_ENABLE	0x00000000	/* Ignored               */
+# define G_SHADING_SMOOTH	0x00200000	/* flat or smooth shaded */
+# define G_CULL_FRONT		0x00000200
+# define G_CULL_BACK		0x00000400
+# define G_CULL_BOTH		0x00000600	/* To make code cleaner */
+#else
+# define G_TEXTURE_ENABLE	0x00000002	/* Microcode use only */
+# define G_SHADING_SMOOTH	0x00000200	/* flat or smooth shaded */
+# define G_CULL_FRONT		0x00001000
+# define G_CULL_BACK		0x00002000
+# define G_CULL_BOTH		0x00003000	/* To make code cleaner */
+#endif
 #define G_FOG			0x00010000
 #define G_LIGHTING		0x00020000
 #define G_TEXTURE_GEN		0x00040000
@@ -1175,8 +1189,10 @@ typedef union {
  * which to store a 1-4 word DMA.
  *
  */
-#ifdef	F3DEX_GBI_2x
-/* 0,2,4,6 are reserved by G_MTX */
+#ifdef	F3DEX_GBI_2
+/* 0,4 are reserved by G_MTX */
+# define G_MV_MMTX	2	
+# define G_MV_PMTX	6
 # define G_MV_VIEWPORT	8
 # define G_MV_LIGHT	10
 # define G_MV_POINT	12
@@ -1224,7 +1240,7 @@ typedef union {
 #define G_MW_SEGMENT		0x06
 #define G_MW_FOG		0x08
 #define G_MW_LIGHTCOL		0x0a
-#ifdef	F3DEX_GBI_2x
+#ifdef	F3DEX_GBI_2
 # define G_MW_FORCEMTX		0x0c
 #else	/* F3DEX_GBI_2 */
 # define G_MW_POINTS		0x0c
@@ -1258,6 +1274,22 @@ typedef union {
 #define G_MWO_FOG		0x00
 #define G_MWO_aLIGHT_1		0x00
 #define G_MWO_bLIGHT_1		0x04
+#ifdef	F3DEX_GBI_2
+#define G_MWO_aLIGHT_2		0x18
+#define G_MWO_bLIGHT_2		0x1c
+#define G_MWO_aLIGHT_3		0x30
+#define G_MWO_bLIGHT_3		0x34
+#define G_MWO_aLIGHT_4		0x48
+#define G_MWO_bLIGHT_4		0x4c
+#define G_MWO_aLIGHT_5		0x60
+#define G_MWO_bLIGHT_5		0x64
+#define G_MWO_aLIGHT_6		0x78
+#define G_MWO_bLIGHT_6		0x7c
+#define G_MWO_aLIGHT_7		0x90
+#define G_MWO_bLIGHT_7		0x94
+#define G_MWO_aLIGHT_8		0xa8
+#define G_MWO_bLIGHT_8		0xac
+#else
 #define G_MWO_aLIGHT_2		0x20
 #define G_MWO_bLIGHT_2		0x24
 #define G_MWO_aLIGHT_3		0x40
@@ -1272,6 +1304,7 @@ typedef union {
 #define G_MWO_bLIGHT_7		0xc4
 #define G_MWO_aLIGHT_8		0xe0
 #define G_MWO_bLIGHT_8		0xe4
+#endif
 #define G_MWO_MATRIX_XX_XY_I	0x00
 #define G_MWO_MATRIX_XZ_XW_I	0x04
 #define G_MWO_MATRIX_YX_YY_I	0x08
@@ -1700,58 +1733,84 @@ typedef union {
 #define	gDma2p(pkt, c, adrs, len, idx, ofs)				\
 {									\
 	Gfx *_g = (Gfx *)(pkt);						\
-	_g->words.w0 = (_SHIFTL((c),24,8)|_SHIFTL((ofs)/8,16,8)|	\
-			_SHIFTL(((len)-1)/8,8,8)|_SHIFTL((idx),0,8));	\
+	_g->words.w0 = (_SHIFTL((c),24,8)|_SHIFTL(((len)-1)/8,19,5)|	\
+			_SHIFTL((ofs)/8,8,8)|_SHIFTL((idx),0,8));	\
 	_g->words.w1 = (unsigned int)(adrs);				\
 }
 #define	gsDma2p(c, adrs, len, idx, ofs)					\
 {									\
-	(_SHIFTL((c),24,8)|_SHIFTL((ofs)/8,16,8)|			\
-	 _SHIFTL(((len)-1)/8,8,8)|_SHIFTL((idx),0,8)),			\
+	(_SHIFTL((c),24,8)|_SHIFTL(((len)-1)/8,19,5)|			\
+	 _SHIFTL((ofs)/8,8,8)|_SHIFTL((idx),0,8)),			\
         (unsigned int)(adrs)						\
 }
 
 #define	gSPNoOp(pkt)		gDma0p(pkt, G_SPNOOP, 0, 0)
 #define	gsSPNoOp()		gsDma0p(G_SPNOOP, 0, 0)
 
-#ifdef	F3DEX_GBI_2x
-# define gSPMatrix(pkt, m, p)	\
-	 gDma2p((pkt),G_MTX,(m),sizeof(Mtx),(p)^G_MTX_PUSH,0)
-# define gsSPMatrix(m, p)	\
-	 gsDma2p(     G_MTX,(m),sizeof(Mtx),(p)^G_MTX_PUSH,0)
+#ifdef	F3DEX_GBI_2
+# define	gSPMatrix(pkt, m, p)	\
+		gDma2p((pkt),G_MTX,(m),sizeof(Mtx),(p)^G_MTX_PUSH,0)
+# define	gsSPMatrix(m, p)	\
+		gsDma2p(     G_MTX,(m),sizeof(Mtx),(p)^G_MTX_PUSH,0)
 #else	/* F3DEX_GBI_2 */
-# define gSPMatrix(pkt, m, p)	gDma1p(pkt, G_MTX, m, sizeof(Mtx), p)
-# define gsSPMatrix(m, p)	gsDma1p(G_MTX, m, sizeof(Mtx), p)
+# define	gSPMatrix(pkt, m, p)	gDma1p(pkt, G_MTX, m, sizeof(Mtx), p)
+# define	gsSPMatrix(m, p)	gsDma1p(G_MTX, m, sizeof(Mtx), p)
 #endif	/* F3DEX_GBI_2 */
 
+#if	defined(F3DEX_GBI_2)
+/*
+ * F3DEX_GBI_2: G_VTX GBI format was changed.
+ *
+ *        +--------+----+---+---+----+------+-+
+ *  G_VTX |  cmd:8 |0000|  n:8  |0000|v0+n:7|0|
+ *        +-+---+--+----+---+---+----+------+-+
+ *        | |seg|         address             |
+ *        +-+---+-----------------------------+
+ */
+# define	gSPVertex(pkt, v, n, v0)				\
+{									\
+	Gfx *_g = (Gfx *)(pkt);						\
+	_g->words.w0 =							\
+	  _SHIFTL(G_VTX,24,8)|_SHIFTL((n),12,8)|_SHIFTL((v0)+(n),1,7);	\
+	_g->words.w1 = (unsigned int)(v);				\
+}
+# define	gsSPVertex(v, n, v0)					\
+{									\
+	(_SHIFTL(G_VTX,24,8)|_SHIFTL((n),12,8)|_SHIFTL((v0)+(n),1,7)),	\
+        (unsigned int)(v)						\
+}
+#elif	(defined(F3DEX_GBI)||defined(F3DLP_GBI))
 /*
  * F3DEX_GBI: G_VTX GBI format was changed to support 64 vertice.
  *
- *        +--------+--------+------+---------------+
- *  G_VTX |  cmd:8 |  v0:8  |  n:6 |  length:10    |
- *        +-+---+--+--------+------+---------------+
- *        | |seg|            address               |
- *        +-+---+----------------------------------+
+ *        +--------+--------+------+----------+
+ *  G_VTX |  cmd:8 |  v0:8  |  n:6 |length:10 |
+ *        +-+---+--+--------+------+----------+
+ *        | |seg|          address            |
+ *        +-+---+-----------------------------+
  */
-#if	(defined(F3DEX_GBI)||defined(F3DLP_GBI))
-#  define gSPVertex(pkt, v, n, v0) \
-                gDma1p(pkt, G_VTX, v, ((n)<<10)|(sizeof(Vtx)*(n)-1), (v0)*2)
-#  define gsSPVertex(v, n, v0) \
-                gsDma1p(G_VTX, v, ((n)<<10)|(sizeof(Vtx)*(n)-1), (v0)*2)
+# define	gSPVertex(pkt, v, n, v0) \
+                gDma1p((pkt),G_VTX,(v),((n)<<10)|(sizeof(Vtx)*(n)-1),(v0)*2)
+# define	gsSPVertex(v, n, v0) \
+                gsDma1p(G_VTX,(v),((n)<<10)|(sizeof(Vtx)*(n)-1),(v0)*2)
 #else
-#  define	gSPVertex(pkt, v, n, v0) \
+# define	gSPVertex(pkt, v, n, v0) \
                 gDma1p(pkt, G_VTX, v, sizeof(Vtx)*(n),((n)-1)<<4|(v0))
-#  define	gsSPVertex(v, n, v0) \
+# define	gsSPVertex(v, n, v0) \
                 gsDma1p(G_VTX, v, sizeof(Vtx)*(n), ((n)-1)<<4|(v0))
 #endif
 
 	
-#ifdef	F3DEX_GBI_2x
-# define gSPViewport(pkt, v) gDma2p(pkt,G_MOVEMEM,v,sizeof(Vp),G_MV_VIEWPORT,0)
-# define gsSPViewport(v)    gsDma2p(    G_MOVEMEM,v,sizeof(Vp),G_MV_VIEWPORT,0)
+#ifdef	F3DEX_GBI_2
+# define gSPViewport(pkt, v)	\
+		gDma2p((pkt), G_MOVEMEM, (v), sizeof(Vp), G_MV_VIEWPORT, 0)
+# define gsSPViewport(v)	\
+		gsDma2p(      G_MOVEMEM, (v), sizeof(Vp), G_MV_VIEWPORT, 0)
 #else	/* F3DEX_GBI_2 */
-# define gSPViewport(pkt,v) gDma1p(pkt,G_MOVEMEM,(v),sizeof(Vp),G_MV_VIEWPORT)
-# define gsSPViewport(v)   gsDma1p(    G_MOVEMEM,(v),sizeof(Vp),G_MV_VIEWPORT)
+# define gSPViewport(pkt,v)	\
+		gDma1p((pkt), G_MOVEMEM, (v), sizeof(Vp), G_MV_VIEWPORT)
+# define gsSPViewport(v)	\
+		gsDma1p(      G_MOVEMEM, (v), sizeof(Vp), G_MV_VIEWPORT)
 #endif	/* F3DEX_GBI_2 */
 
 #define	gSPDisplayList(pkt,dl)	gDma1p(pkt,G_DL,dl,0,G_DL_PUSH)
@@ -1834,7 +1893,7 @@ typedef union {
         (unsigned int) (dat)						\
 }
 
-#ifdef	F3DEX_GBI_2 // F3DEX_GBI_2x
+#ifdef	F3DEX_GBI_2
 #define gMoveWd(pkt, index, offset, data)				\
 	gDma1p((pkt), G_MOVEWORD, data, offset, index)
 #define gsMoveWd(    index, offset, data)				\
@@ -1901,6 +1960,16 @@ typedef union {
 #  define __gsSPLine3D_w1f(v0, v1, wd, flag)			\
      (((flag) == 0) ? __gsSPLine3D_w1(v0, v1, wd):		\
 	              __gsSPLine3D_w1(v1, v0, wd))
+#  define __gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag)	\
+  (((flag) == 0) ? __gsSP1Triangle_w1(v0, v1, v2):      \
+   ((flag) == 1) ? __gsSP1Triangle_w1(v1, v2, v3):      \
+   ((flag) == 2) ? __gsSP1Triangle_w1(v2, v3, v0):      \
+                   __gsSP1Triangle_w1(v3, v0, v1))
+#  define __gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag)	\
+  (((flag) == 0) ? __gsSP1Triangle_w1(v0, v2, v3):      \
+   ((flag) == 1) ? __gsSP1Triangle_w1(v1, v3, v0):      \
+   ((flag) == 2) ? __gsSP1Triangle_w1(v2, v0, v1):      \
+                   __gsSP1Triangle_w1(v3, v1, v2))
 #else
 #  define __gsSP1Triangle_w1f(v0, v1, v2, flag)			\
      (_SHIFTL((flag), 24,8)|_SHIFTL((v0)*10,16,8)|		\
@@ -1910,6 +1979,7 @@ typedef union {
       _SHIFTL((v1)*10, 8,8)|_SHIFTL((wd),    0,8))
 #endif
 
+#ifdef	F3DEX_GBI_2
 /***
  ***  1 Triangle
  ***/
@@ -1917,10 +1987,86 @@ typedef union {
 {									\
 	Gfx *_g = (Gfx *)(pkt);						\
 									\
+	_g->words.w0 = _SHIFTL(G_TRI1, 24, 8)|				\
+			__gsSP1Triangle_w1f(v0, v1, v2, flag);		\
+	_g->words.w1 = 0;						\
+}
+#define gsSP1Triangle(v0, v1, v2, flag)					\
+{									\
+	_SHIFTL(G_TRI1, 24, 8)|__gsSP1Triangle_w1f(v0, v1, v2, flag),	\
+	0								\
+}
+
+/***
+ ***  Line
+ ***/
+#define gSPLine3D(pkt, v0, v1, flag)					\
+{									\
+	Gfx *_g = (Gfx *)(pkt);						\
+									\
+	_g->words.w0 = _SHIFTL(G_LINE3D, 24, 8)|			\
+			__gsSPLine3D_w1f(v0, v1, 0, flag);		\
+	_g->words.w1 = 0;						\
+}
+#define gsSPLine3D(v0, v1, flag)					\
+{									\
+	_SHIFTL(G_LINE3D, 24, 8)|__gsSPLine3D_w1f(v0, v1, 0, flag),	\
+	0								\
+}
+
+/***
+ ***  LineW
+ ***/
+/* these macros are the same as SPLine3D, except they have an
+ * additional parameter for width. The width is added to the "minimum"
+ * thickness, which is 1.5 pixels. The units for width are in
+ * half-pixel units, so a width of 1 translates to (.5 + 1.5) or
+ * a 2.0 pixels wide line.
+ */
+#define gSPLineW3D(pkt, v0, v1, wd, flag)				\
+{									\
+	Gfx *_g = (Gfx *)(pkt);						\
+									\
+	_g->words.w0 = _SHIFTL(G_LINE3D, 24, 8)|			\
+			__gsSPLine3D_w1f(v0, v1, wd, flag);		\
+	_g->words.w1 = 0;						\
+}
+#define gsSPLineW3D(v0, v1, wd, flag)					\
+{									\
+	_SHIFTL(G_LINE3D, 24, 8)|__gsSPLine3D_w1f(v0, v1, wd, flag),	\
+	0								\
+}
+
+/***
+ ***  1 Quadrangle
+ ***/
+#define gSP1Quadrangle(pkt, v0, v1, v2, v3, flag)                       \
+{                                                                       \
+        Gfx *_g = (Gfx *)(pkt);                                         \
+                                                                        \
+        _g->words.w0 = (_SHIFTL(G_QUAD, 24, 8)|	                        \
+                        __gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag));   \
+        _g->words.w1 =  __gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag);    \
+}
+
+#define gsSP1Quadrangle(v0, v1, v2, v3, flag)                           \
+{                                                                       \
+        (_SHIFTL(G_QUAD, 24, 8)|                                        \
+         __gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag)),                  \
+         __gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag)                    \
+}
+#else	/* F3DEX_GBI_2 */
+
+/***
+ ***  1 Triangle
+ ***/	
+#define gSP1Triangle(pkt, v0, v1, v2, flag)				\
+{									\
+	Gfx *_g = (Gfx *)(pkt);						\
+									\
 	_g->words.w0 = _SHIFTL(G_TRI1, 24, 8);				\
 	_g->words.w1 = __gsSP1Triangle_w1f(v0, v1, v2, flag);		\
 }
-
 #define gsSP1Triangle(v0, v1, v2, flag)					\
 {									\
 	_SHIFTL(G_TRI1, 24, 8),						\
@@ -1937,7 +2083,6 @@ typedef union {
 	_g->words.w0 = _SHIFTL(G_LINE3D, 24, 8);			\
 	_g->words.w1 = __gsSPLine3D_w1f(v0, v1, 0, flag);		\
 }
-
 #define gsSPLine3D(v0, v1, flag)					\
 {									\
 	_SHIFTL(G_LINE3D, 24, 8),					\
@@ -1960,12 +2105,31 @@ typedef union {
 	_g->words.w0 = _SHIFTL(G_LINE3D, 24, 8);			\
 	_g->words.w1 = __gsSPLine3D_w1f(v0, v1, wd, flag);		\
 }
-
 #define gsSPLineW3D(v0, v1, wd, flag)					\
 {									\
 	_SHIFTL(G_LINE3D, 24, 8),					\
 	__gsSPLine3D_w1f(v0, v1, wd, flag)				\
 }
+
+/***
+ ***  1 Quadrangle
+ ***/
+#define gSP1Quadrangle(pkt, v0, v1, v2, v3, flag)                       \
+{                                                                       \
+        Gfx *_g = (Gfx *)(pkt);                                         \
+                                                                        \
+        _g->words.w0 = (_SHIFTL(G_TRI2, 24, 8)|	                        \
+                        __gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag));   \
+        _g->words.w1 =  __gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag);    \
+}
+
+#define gsSP1Quadrangle(v0, v1, v2, v3, flag)                           \
+{                                                                       \
+        (_SHIFTL(G_TRI2, 24, 8)|                                        \
+         __gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag)),                  \
+         __gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag)                    \
+}
+#endif	/* F3DEX_GBI_2 */
 
 #if	(defined(F3DLP_GBI)||defined(F3DEX_GBI))
 /***
@@ -1987,36 +2151,6 @@ typedef union {
 	 __gsSP1Triangle_w1f(v10, v11, v12, flag1)			\
 }
 
-/***
- ***  1 Quadrangle
- ***/
-#define	__gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag)	\
-  (((flag) == 0) ? __gsSP1Triangle_w1(v0, v1, v2):      \
-   ((flag) == 1) ? __gsSP1Triangle_w1(v1, v2, v3):      \
-   ((flag) == 2) ? __gsSP1Triangle_w1(v2, v3, v0):      \
-                   __gsSP1Triangle_w1(v3, v0, v1))
-
-#define	__gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag)	\
-  (((flag) == 0) ? __gsSP1Triangle_w1(v0, v2, v3):      \
-   ((flag) == 1) ? __gsSP1Triangle_w1(v1, v3, v0):      \
-   ((flag) == 2) ? __gsSP1Triangle_w1(v2, v0, v1):      \
-                   __gsSP1Triangle_w1(v3, v1, v2))
-
-#define gSP1Quadrangle(pkt, v0, v1, v2, v3, flag)                       \
-{                                                                       \
-        Gfx *_g = (Gfx *)(pkt);                                         \
-                                                                        \
-        _g->words.w0 = (_SHIFTL(G_TRI2, 24, 8)|	                        \
-                        __gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag));   \
-        _g->words.w1 =  __gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag);    \
-}
-
-#define gsSP1Quadrangle(v0, v1, v2, v3, flag)                           \
-{                                                                       \
-        (_SHIFTL(G_TRI2, 24, 8)|                                        \
-         __gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag)),                  \
-         __gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag)                    \
-}
 #endif	/* F3DEX_GBI/F3DLP_GBI */
 
 #if	(defined(F3DEX_GBI)||defined(F3DLP_GBI))
@@ -2096,8 +2230,11 @@ typedef union {
  * num   = new element (32 bit value replacing 2 int or 2 frac matrix 
  *                                 componants
  */
-#ifdef	F3DEX_GBI_2x
-ERROR!! gSPInsertMatrix is no longer supported.
+#ifdef	F3DEX_GBI_2
+#define gSPInsertMatrix(pkt, where, num)				\
+	ERROR!! gSPInsertMatrix is no longer supported.
+#define gsSPInsertMatrix(where, num)					\
+	ERROR!! gsSPInsertMatrix is no longer supported.
 #else
 #define gSPInsertMatrix(pkt, where, num)				\
 	gMoveWd(pkt, G_MW_MATRIX, where, num)
@@ -2110,7 +2247,7 @@ ERROR!! gSPInsertMatrix is no longer supported.
  *
  * mptr = pointer to matrix
  */
-#ifdef	F3DEX_GBI_2x
+#ifdef	F3DEX_GBI_2
 #define	gSPForceMatrix(pkt, mptr)					\
 {	gDma2p((pkt),G_MOVEMEM,(mptr),sizeof(Mtx),G_MV_MATRIX,0);	\
 	gMoveWd((pkt), G_MW_FORCEMTX,0,0x00010000);			\
@@ -2271,10 +2408,35 @@ ERROR!! gSPInsertMatrix is no longer supported.
 		      OS_K0_TO_PHYSICAL(&##ucode##DataStart))
 #endif
 
+#ifdef	F3DEX_GBI_2
+/*
+ * gSPDma_io  DMA to/from DMEM/IMEM for DEBUG.
+ */
+#define	gSPDma_io(pkt, flag, dmem, dram, size)				\
+{									\
+	Gfx *_g = (Gfx *)(pkt);						\
+	_g->words.w0 = _SHIFTL(G_DMA_IO,24,8)|_SHIFTL((flag),23,1)|	\
+	  _SHIFTL((dmem)/8,13,10)|_SHIFTL((size)-1,0,12);		\
+	_g->words.w1 = (unsigned int)(dram);				\
+}
+
+#define	gsSPDma_io(flag, dmem, dram, size)				\
+{									\
+	_SHIFTL(G_DMA_IO,24,8)|_SHIFTL((flag),23,1)|			\
+	_SHIFTL((dmem)/8,13,10)|_SHIFTL((size)-1,0,12),			\
+	(unsigned int)(dram)						\
+}
+
+#define	gSPDmaRead(pkt,dmem,dram,size)	gSPDma_io((pkt),0,(dmem),(dram),(size))
+#define	gsSPDmaRead(dmem,dram,size)	gsSPDma_io(0,(dmem),(dram),(size))
+#define	gSPDmaWrite(pkt,dmem,dram,size)	gSPDma_io((pkt),1,(dmem),(dram),(size))
+#define	gsSPDmaWrite(dmem,dram,size)	gsSPDma_io(1,(dmem),(dram),(size))
+#endif
+
 /*
  * Lighting Macros
  */
-#ifdef	F3DEX_GBI_2x
+#ifdef	F3DEX_GBI_2
 # define NUML(n)	((n)*24)
 #else
 # define NUML(n)	(((n)+1)*32 + 0x80000000)
@@ -2313,11 +2475,11 @@ ERROR!! gSPInsertMatrix is no longer supported.
  *       LIGHT_1 through LIGHT_3 will be the directional lights and light
  *       LIGHT_4 will be the ambient light.
  */
-#ifdef	F3DEX_GBI_2x
+#ifdef	F3DEX_GBI_2
 # define gSPLight(pkt, l, n)	\
-	  gDma2p((pkt),G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,(n)*3+3)
+	  gDma2p((pkt),G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,(n)*24+24)
 # define gsSPLight(l, n)	\
-	 gsDma2p(      G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,(n)*3+3)
+	 gsDma2p(      G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,(n)*24+24)
 #else	/* F3DEX_GBI_2 */
 # define gSPLight(pkt, l, n)	\
 	 gDma1p(pkt, G_MOVEMEM, l, sizeof(Light),((n)-1)*2+G_MV_L0)
@@ -2479,13 +2641,13 @@ ERROR!! gSPInsertMatrix is no longer supported.
  */
 #ifdef	F3DEX_GBI_2
 # define gSPLookAtX(pkt, l)	\
-	 gDma2p((pkt),G_MOVEMEM,(l),sizeof(Light),G_MV_LOOKATX,0)
+	 gDma2p((pkt),G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,G_MVO_LOOKATX)
 # define gsSPLookAtX(l)		\
-	 gsDma2p(     G_MOVEMEM,(l),sizeof(Light),G_MV_LOOKATX,0)
+	 gsDma2p(     G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,G_MVO_LOOKATX)
 # define gSPLookAtY(pkt, l)	\
-	 gDma2p((pkt),G_MOVEMEM,(l),sizeof(Light),G_MV_LOOKATY,0)
+	 gDma2p((pkt),G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,G_MVO_LOOKATY)
 # define gsSPLookAtY(l)		\
-	 gsDma2p(     G_MOVEMEM,(l),sizeof(Light),G_MV_LOOKATY,0)
+	 gsDma2p(     G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,G_MVO_LOOKATY)
 #else	/* F3DEX_GBI_2 */
 # define gSPLookAtX(pkt, l)	\
 	 gDma1p(pkt, G_MOVEMEM, l, sizeof(Light),G_MV_LOOKATX)
@@ -2551,56 +2713,90 @@ ERROR!! gSPInsertMatrix is no longer supported.
 		(_SHIFTL((128000/((max)-(min))),16,16) |		\
 		_SHIFTL(((500-(min))*256/((max)-(min))),0,16)))
 
+#ifdef	F3DEX_GBI_2
 /*
  * Macros to turn texture on/off
  */
-#define	gSPTexture(pkt, s, t, level, tile, on)				\
+# define gSPTexture(pkt, s, t, level, tile, on)				\
 {									\
 	Gfx *_g = (Gfx *)(pkt);						\
 									\
-	_g->words.w0 = (_SHIFTL(G_TEXTURE, 24, 8) | 			\
-			_SHIFTL(BOWTIE_VAL, 16, 8) |			\
-			_SHIFTL(level, 11, 3) | _SHIFTL(tile, 8, 3) |	\
-			_SHIFTL(on, 0, 8));				\
-	_g->words.w1 = (_SHIFTL(s, 16, 16) | _SHIFTL(t, 0, 16));	\
+	_g->words.w0 = (_SHIFTL(G_TEXTURE,24,8) | 			\
+			_SHIFTL(BOWTIE_VAL,16,8) |			\
+			_SHIFTL((level),11,3) | _SHIFTL((tile),8,3) |	\
+			_SHIFTL((on),1,7));				\
+	_g->words.w1 = (_SHIFTL((s),16,16) | _SHIFTL((t),0,16));	\
 }
-
-#define	gsSPTexture(s, t, level, tile, on)				\
+# define gsSPTexture(s, t, level, tile, on)				\
 {									\
-	(_SHIFTL(G_TEXTURE, 24, 8) |  _SHIFTL(BOWTIE_VAL, 16, 8) |	\
-	 _SHIFTL(level, 11, 3) | _SHIFTL(tile, 8, 3) | _SHIFTL(on, 0, 8)),\
-        (_SHIFTL(s, 16, 16) | _SHIFTL(t, 0, 16))			\
+	(_SHIFTL(G_TEXTURE,24,8) | _SHIFTL(BOWTIE_VAL,16,8) |		\
+	 _SHIFTL((level),11,3) | _SHIFTL((tile),8,3) | _SHIFTL((on),1,7)),\
+        (_SHIFTL((s),16,16) | _SHIFTL((t),0,16))			\
 }
-
 /* 
  * Different version of SPTexture macro, has an additional parameter
  * which is currently reserved in the microcode.
  */
-#define	gSPTextureL(pkt, s, t, level, xparam, tile, on)			\
+# define gSPTextureL(pkt, s, t, level, xparam, tile, on)		\
 {									\
 	Gfx *_g = (Gfx *)(pkt);						\
 									\
-	_g->words.w0 = (_SHIFTL(G_TEXTURE, 24, 8) | 			\
-			_SHIFTL(xparam, 16, 8) | 			\
-			_SHIFTL(level, 11, 3) | _SHIFTL(tile, 8, 3) |	\
-			_SHIFTL(on, 0, 8));				\
-	_g->words.w1 = (_SHIFTL(s, 16, 16) | _SHIFTL(t, 0, 16));	\
+	_g->words.w0 = (_SHIFTL(G_TEXTURE,24,8) | 			\
+			_SHIFTL((xparam),16,8) | 			\
+			_SHIFTL((level),11,3) | _SHIFTL((tile),8,3) |	\
+			_SHIFTL((on),1,7));				\
+	_g->words.w1 = (_SHIFTL((s),16,16) | _SHIFTL((t),0,16));	\
 }
-
-#define	gsSPTextureL(s, t, level, xparam, tile, on)			\
+# define gsSPTextureL(s, t, level, xparam, tile, on)			\
 {									\
-	(_SHIFTL(G_TEXTURE, 24, 8) |  _SHIFTL(xparam, 16, 8) |		\
-	 _SHIFTL(level, 11, 3) | _SHIFTL(tile, 8, 3) | _SHIFTL(on, 0, 8)),\
-        (_SHIFTL(s, 16, 16) | _SHIFTL(t, 0, 16))			\
+	(_SHIFTL(G_TEXTURE,24,8) | _SHIFTL((xparam),16,8) |		\
+	 _SHIFTL((level),11,3) | _SHIFTL((tile),8,3) | _SHIFTL((on),1,7)),\
+        (_SHIFTL((s),16,16) | _SHIFTL((t),0,16))			\
 }
+#else
+/*
+ * Macros to turn texture on/off
+ */
+# define gSPTexture(pkt, s, t, level, tile, on)				\
+{									\
+	Gfx *_g = (Gfx *)(pkt);						\
+									\
+	_g->words.w0 = (_SHIFTL(G_TEXTURE,24,8)|_SHIFTL(BOWTIE_VAL,16,8)|\
+			_SHIFTL((level),11,3)|_SHIFTL((tile),8,3)|	\
+			_SHIFTL((on),0,8));				\
+	_g->words.w1 = (_SHIFTL((s),16,16)|_SHIFTL((t),0,16));		\
+}
+# define gsSPTexture(s, t, level, tile, on)				\
+{									\
+	(_SHIFTL(G_TEXTURE,24,8)|_SHIFTL(BOWTIE_VAL,16,8)|		\
+	 _SHIFTL((level),11,3)|_SHIFTL((tile),8,3)|_SHIFTL((on),0,8)),	\
+        (_SHIFTL((s),16,16)|_SHIFTL((t),0,16))				\
+}
+/* 
+ * Different version of SPTexture macro, has an additional parameter
+ * which is currently reserved in the microcode.
+ */
+# define gSPTextureL(pkt, s, t, level, xparam, tile, on)		\
+{									\
+	Gfx *_g = (Gfx *)(pkt);						\
+									\
+	_g->words.w0 = (_SHIFTL(G_TEXTURE,24,8)|_SHIFTL((xparam),16,8)|	\
+			_SHIFTL((level),11,3)|_SHIFTL((tile),8,3)|	\
+			_SHIFTL((on),0,8));				\
+	_g->words.w1 = (_SHIFTL((s),16,16)|_SHIFTL((t),0,16));		\
+}
+# define gsSPTextureL(s, t, level, xparam, tile, on)			\
+{									\
+	(_SHIFTL(G_TEXTURE,24,8)|_SHIFTL((xparam),16,8)|		\
+	 _SHIFTL((level),11,3)|_SHIFTL((tile),8,3)|_SHIFTL((on),0,8)),	\
+        (_SHIFTL((s),16,16)|_SHIFTL((t),0,16))				\
+}
+#endif
 
+#define gSPPerspNormalize(pkt, s)	gMoveWd(pkt, G_MW_PERSPNORM, 0, (s))
+#define gsSPPerspNormalize(s)		gsMoveWd(    G_MW_PERSPNORM, 0, (s))
 
-#define gSPPerspNormalize(pkt, s)					\
-	gMoveWd(pkt, G_MW_PERSPNORM, 0, (s))
-#define gsSPPerspNormalize(s)						\
-	gsMoveWd(    G_MW_PERSPNORM, 0, (s))
-
-#ifdef	F3DEX_GBI_2x
+#ifdef	F3DEX_GBI_2
 # define gSPPopMatrixN(pkt, n, num)	gDma2p((pkt),G_POPMTX,(num)*64,64,2,0)
 # define gsSPPopMatrixN(n, num)		gsDma2p(     G_POPMTX,(num)*64,64,2,0)
 # define gSPPopMatrix(pkt, n)		gSPPopMatrixN((pkt), (n), 1)
@@ -2623,7 +2819,7 @@ ERROR!! gSPInsertMatrix is no longer supported.
 	_SHIFTL(G_ENDDL, 24, 8), 0					\
 }
 
-#ifdef	F3DEX_GBI_2x
+#ifdef	F3DEX_GBI_2
 /*
  *	One gSPGeometryMode(pkt,c,s) GBI is equal to these two GBIs.
  *
@@ -2678,7 +2874,7 @@ ERROR!! gSPInsertMatrix is no longer supported.
 }
 #endif	/* F3DEX_GBI_2 */
 
-#ifdef	F3DEX_GBI_2x
+#ifdef	F3DEX_GBI_2
 #define	gSPSetOtherMode(pkt, cmd, sft, len, data)			\
 {									\
 	Gfx *_g = (Gfx *)(pkt);						\

--- a/include/PR/gs2dex.h
+++ b/include/PR/gs2dex.h
@@ -6,7 +6,7 @@
 	Modified by	
 	Comments	Header file for S2DEX ucode.
 	
-	$Id: gs2dex.h,v 1.15 1997/10/17 08:19:07 yasu Exp $
+	$Id: gs2dex.h,v 1.19 1998/04/09 07:32:02 yasu Exp $
   ---------------------------------------------------------------------*/
 
 #ifndef	_GS2DEX_H_
@@ -38,66 +38,65 @@ extern "C" {
 
 /* Non scalable background plane */
 typedef	struct	{
-  u16   imageX;		/* The x-coordinate of the upper-left position of the texture.  (u11.5)*/ 
-  u16	imageW;		/* The width of the texture.                                    (u10.2)*/
-  s16	frameX;		/* The upper-left position of the transferred frame.            (s10.2)*/
-  u16	frameW;		/* The width of the transferred frame.                          (u10.2)*/
+  u16   imageX;		/* x-coordinate of upper-left position of texture (10.5) */ 
+  u16	imageW;		/* width of the texture (u10.2) */
+  s16	frameX;		/* upper-left position of transferred frame (s10.2) */
+  u16	frameW;		/* width of transferred frame (u10.2) */
 
-  u16   imageY; 	/* The y-coordinate of the upper-left position of the texture.  (u11.5)*/ 
-  u16	imageH;		/* The height of the texture.                                   (u10.2)*/
-  s16	frameY;		/* The upper-left position of the transferred frame.            (s10.2)*/
-  u16	frameH;		/* The height of the transferred frame.                         (u10.2)*/
+  u16 imageY;     	/* y-coordinate of upper-left position of texture (u10.5) */ 
+  u16	imageH;		/* height of the texture (u10.2) */
+  s16	frameY;		/* upper-left position of transferred frame (s10.2) */
+  u16	frameH;		/* height of transferred frame (u10.2) */
 
-  u64  *imagePtr;	/* The texture source address on DRAM.           */
-  u16	imageLoad;	/* Which to use,  LoadBlock or  LoadTile?        */
-  u8	imageFmt;	/* The format of the texel.  G_IM_FMT_*          */
-  u8	imageSiz;	/* The size of the texel        G_IM_SIZ_*       */
-  u16   imagePal; 	/* The pallet number.                            */
-  u16	imageFlip;	/* The right & left inversion of the image. Inverted by G_BG_FLAG_FLIPS*/
+  u64  *imagePtr;	/* texture source address on DRAM */
+  u16	imageLoad;	/* which to use, LoadBlock or  LoadTile */
+  u8	imageFmt;	/* format of texel - G_IM_FMT_*  */
+  u8	imageSiz;	/* size of texel - G_IM_SIZ_*  */
+  u16   imagePal; /* pallet number */
+  u16	imageFlip;	/* right & left image inversion (Inverted by G_BG_FLAG_FLIPS) */
 
-  /* Because the following are set in the initialization routine guS2DInitBg(), the user doesn't 
-     have to set it.*/
-  u16	tmemW;		/* The TMEM width and Work size of the frame 1 line. 
-                           At LoadBlock, GS_PIX2TMEM(imageW/4,imageSiz)
-                           At LoadTile  GS_PIX2TMEM(frameW/4,imageSiz)+1  */
-  u16	tmemH;		/* The height of TMEM loadable at a time.  (s13.2) The 4 times value.
-			   When the normal texture,   512/tmemW*4
-			   When the CI texture,    256/tmemW*4       */
-  u16	tmemLoadSH;	/* The SH value
-			   At LoadBlock,  tmemSize/2-1
-			   At LoadTile,  tmemW*16-1                  */
-  u16	tmemLoadTH;	/* The TH value or the Stride value 
-			   At LoadBlock,  GS_CALC_DXT(tmemW)
-			   At LoadTile,  tmemH-1                     */
-  u16	tmemSizeW;	/* The skip value of imagePtr for image 1-line.  
+  /* Because following are set in initialization routine guS2DInitBg(), user doesn't have to set it*/
+  u16	tmemW;	/* TMEM width and Word size of frame 1 line. 
+                     At LoadBlock, GS_PIX2TMEM(imageW/4,imageSiz)
+                     At LoadTile  GS_PIX2TMEM(frameW/4,imageSiz)+1  */
+  u16	tmemH;	/* height of TMEM loadable at a time (s13.2) 4 times value
+			   When the normal texture, 512/tmemW*4
+			   When the CI texture, 256/tmemW*4 */
+  u16	tmemLoadSH;	/* SH value
+			   At LoadBlock, tmemSize/2-1
+			   At LoadTile, tmemW*16-1 */
+  u16	tmemLoadTH;	/* TH value or Stride value 
+			   At LoadBlock, GS_CALC_DXT(tmemW)
+			   At LoadTile, tmemH-1 */
+  u16	tmemSizeW;	/* skip value of imagePtr for image 1-line  
 			   At LoadBlock, tmemW*2
-                           At LoadTile,  GS_PIX2TMEM(imageW/4,imageSiz)*2 */
-  u16	tmemSize;	/* The skip value of  imagePtr for 1-loading.  
-			   = tmemSizeW*tmemH                         */
+                     At LoadTile, GS_PIX2TMEM(imageW/4,imageSiz)*2 */
+  u16	tmemSize;	/* skip value of imagePtr for 1-loading  
+			   = tmemSizeW*tmemH */
 } uObjBg_t;		/* 40 bytes */
 
 /* Scalable background plane */
 typedef	struct	{
-  u16   imageX;		/* The x-coordinate of the upper-left position of the texture.  (u11.5)*/ 
-  u16	imageW;		/* The width of the texture.                                    (u10.2)*/
-  s16	frameX;		/* The upper-left position of the transferred frame.            (s10.2)*/
-  u16	frameW;		/* The width of the transferred frame.                          (u10.2)*/
+  u16   imageX;		/* x-coordinate of upper-left position of texture (u10.5) */ 
+  u16	imageW;		/* width of texture (u10.2) */
+  s16	frameX;		/* upper-left position of transferred frame (s10.2) */
+  u16	frameW;		/* width of transferred frame (u10.2) */
 
-  u16   imageY; 	/* The y-coordinate of the upper-left position of the texture.  (u11.5)*/ 
-  u16	imageH;		/* The height of the texture.                                   (u10.2)*/
-  s16	frameY;		/* The upper-left position of the transferred frame.            (s10.2)*/
-  u16	frameH;		/* The height of the transferred frame.                         (u10.2)*/
+  u16   imageY;   	/* y-coordinate of upper-left position of texture (u10.5) */ 
+  u16	imageH;		/* height of texture (u10.2) */
+  s16	frameY;		/* upper-left position of transferred frame (s10.2) */
+  u16	frameH;		/* height of transferred frame (u10.2) */
 
-  u64  *imagePtr;	/* The texture source address on DRAM.       */
-  u16	imageLoad;	/* Which to use,  LoadBlock or  LoadTile?    */
-  u8	imageFmt;	/* The format of the texel.   G_IM_FMT_*     */
-  u8	imageSiz;	/* The size of the texel      G_IM_SIZ_*     */
-  u16   imagePal; 	/* The pallet number.                        */
-  u16	imageFlip;	/* The right & left inversion of the image. Inverted by G_BG_FLAG_FLIPS*/
+  u64  *imagePtr;	/* texture source address on DRAM */
+  u16	imageLoad;	/* Which to use, LoadBlock or LoadTile? */
+  u8	imageFmt;	/* format of texel - G_IM_FMT_*  */
+  u8	imageSiz;	/* size of texel - G_IM_SIZ_*  */
+  u16   imagePal; /* pallet number */
+  u16	imageFlip;	/* right & left image inversion (Inverted by G_BG_FLAG_FLIPS) */
 
-  u16	scaleW;		/* The scale value of the X-direction.           (u5.10)*/
-  u16	scaleH;		/* The scale value of the Y-direction.           (u5.10)*/
-  s32	imageYorig;	/* The start point of drawing on the image.      (s20.5)*/
+  u16	scaleW;	/* scale value of X-direction (u5.10) */
+  u16	scaleH;	/* scale value of Y-direction (u5.10) */
+  s32	imageYorig;	/* start point of drawing on image (s20.5) */
   
   u8	padding[4];
   
@@ -112,25 +111,25 @@ typedef union {
 /*---------------------------------------------------------------------------*
  *	2D Objects
  *---------------------------------------------------------------------------*/
-#define	G_OBJ_FLAG_FLIPS	1<<0		/* The inversion to the S-direction.  */
-#define	G_OBJ_FLAG_FLIPT	1<<4		/* The inversion to the T-direction.  */
+#define	G_OBJ_FLAG_FLIPS	1<<0		/* inversion to S-direction */
+#define	G_OBJ_FLAG_FLIPT	1<<4		/* inversion to T-direction */
 
 typedef struct {
-  s16  objX;		/* The x-coordinate of the upper-left end. s10.2 OBJ                */
-  u16  scaleW;		/* Scaling of the u5.10 width direction.                            */
-  u16  imageW;		/* The width of the u10.5 texture. (The length of the S-direction.) */
-  u16  paddingX;	/* Unused.  Always 0.                                               */
-  s16  objY;		/* The y-coordinate of the s10.2 OBJ upper-left end.                */
-  u16  scaleH;		/* Scaling of the u5.10 height direction.                           */
-  u16  imageH;		/* The height of the u10.5 texture. (The length of the T-direction.)*/
-  u16  paddingY;	/* Unused.  Always 0.                                               */
-  u16  imageStride;	/* The folding width of the texel.        (In units of 64bit word.) */
-  u16  imageAdrs;	/* The texture header position in  TMEM.  (In units of 64bit word.) */  
-  u8   imageFmt;	/* The format of the texel.   G_IM_FMT_*       */
-  u8   imageSiz;	/* The size of the texel.         G_IM_SIZ_*       */
-  u8   imagePal;	/*The pallet number.  0-7                        */
-  u8   imageFlags;	/* The display flag.    G_OBJ_FLAG_FLIP*            */
-} uObjSprite_t;		/* 24 bytes */
+  s16  objX;	/* s10.2 OBJ x-coordinate of upper-left end */
+  u16  scaleW;	/* u5.10 Scaling of u5.10 width direction */
+  u16  imageW;	/* u10.5 width of u10.5 texture (length of S-direction) */
+  u16  paddingX;	/* Unused - Always 0 */
+  s16  objY;	/* s10.2 OBJ y-coordinate of s10.2 OBJ upper-left end*/
+  u16  scaleH;	/* u5.10 Scaling of u5.10 height direction*/
+  u16  imageH;	/* u10.5 height of u10.5 texture (length of T-direction) */
+  u16  paddingY;	/* Unused - Always 0 */
+  u16  imageStride;	/* folding width of texel (In units of 64bit word) */
+  u16  imageAdrs;	/* texture header position in TMEM (In units of 64bit word) */  
+  u8   imageFmt;	/* format of texel - G_IM_FMT_*  */
+  u8   imageSiz;	/* size of texel - G_IM_SIZ_*  */
+  u8   imagePal;	/* pallet number (0-7) */
+  u8   imageFlags;	/* The display flag - G_OBJ_FLAG_FLIP*  */
+} uObjSprite_t;	/* 24 bytes */
 
 typedef union {
   uObjSprite_t      s;
@@ -174,12 +173,12 @@ typedef union {
 #define	GS_TB_TLINE(pix,siz)	(GS_CALC_DXT(GS_PIX2TMEM((pix),(siz))))
 
 typedef	struct	{
-  u32	type;		/* G_OBJLT_TXTRBLOCK divided into types.                                */
-  u64	*image;		/* The texture source address on DRAM.                                  */
-  u16	tmem;		/* The  transferred TMEM word address.   (8byteWORD)                    */
-  u16	tsize;		/* The Texture size.  Specified by the macro  GS_TB_TSIZE().            */
-  u16	tline;		/* The width of the Texture 1-line. Specified by the macro GS_TB_TLINE()*/
-  u16	sid;		/* STATE ID Multipled by 4.  Either one of  0,4,8 and 12.               */
+  u32	type;		/* G_OBJLT_TXTRBLOCK divided into types */
+  u64	*image;	/* texture source address on DRAM */
+  u16	tmem;		/* loaded TMEM word address (8byteWORD) */
+  u16	tsize;	/* Texture size, Specified by macro GS_TB_TSIZE() */
+  u16	tline;	/* width of Texture 1-line, Specified by macro GS_TB_TLINE() */
+  u16	sid;		/* STATE ID Multipled by 4 (Either one of  0, 4, 8 and 12) */
   u32	flag;		/* STATE flag  */
   u32	mask;		/* STATE mask  */
 } uObjTxtrBlock_t;		/* 24 bytes */
@@ -188,12 +187,12 @@ typedef	struct	{
 #define	GS_TT_THEIGHT(pix,siz)	(((pix)<<2)-1)
 
 typedef	struct	{
-  u32	type;		/* G_OBJLT_TXTRTILE divided into types.                             */
-  u64	*image;		/* The texture source address on DRAM.                              */
-  u16	tmem;		/* The loaded texture source address on DRAM.  (8byteWORD)          */
-  u16	twidth;		/* The width of the Texture. Specified by the macro GS_TT_TWIDTH()  */
-  u16	theight;	/* The height of the Texture. Specified by the macro GS_TT_THEIGHT()*/
-  u16	sid;		/* STATE ID  Multiplied by 4.  Either one of 0,4,8 and 12.          */
+  u32	type;		/* G_OBJLT_TXTRTILE divided into types */
+  u64	*image;	/* texture source address on DRAM */
+  u16	tmem;		/* loaded TMEM word address (8byteWORD) */
+  u16	twidth;	/* width of Texture (Specified by macro GS_TT_TWIDTH()) */
+  u16	theight;	/* height of Texture (Specified by macro GS_TT_THEIGHT()) */
+  u16	sid;		/* STATE ID Multipled by 4 (Either one of  0, 4, 8 and 12) */
   u32	flag;		/* STATE flag  */
   u32	mask;		/* STATE mask  */
 } uObjTxtrTile_t;		/* 24 bytes */
@@ -202,12 +201,12 @@ typedef	struct	{
 #define	GS_PAL_NUM(num)		((num)-1)
 
 typedef	struct	{
-  u32	type;		/* G_OBJLT_TLUT divided into types.                            */
-  u64	*image;		/* the texture source address on DRAM.                         */
-  u16	phead;		/* The pallet number of the load header.  Between 256 and 511. */
-  u16	pnum;		/* The loading pallet number -1.                               */
-  u16   zero;		/* Assign 0 all the time.                                      */
-  u16	sid;		/* STATE ID  Multiplied by 4.  Either one of 0,4,8 and 12.     */
+  u32	type;		/* G_OBJLT_TLUT divided into types */
+  u64	*image;	/* texture source address on DRAM */
+  u16	phead;	/* pallet number of load header (Between 256 and 511) */
+  u16	pnum;		/* loading pallet number -1 */
+  u16   zero;	/* Assign 0 all the time */
+  u16	sid;		/* STATE ID Multipled by 4 (Either one of  0, 4, 8 and 12) */
   u32	flag;		/* STATE flag  */
   u32	mask;		/* STATE mask  */
 } uObjTxtrTLUT_t;		/* 24 bytes */
@@ -231,6 +230,21 @@ typedef	struct	{
  *	GBI Commands for S2DEX microcode
  *===========================================================================*/
 /* GBI Header */
+#ifdef	F3DEX_GBI_2
+#define	G_OBJ_RECTANGLE_R	0xda
+#define	G_OBJ_MOVEMEM		0xdc
+#define	G_RDPHALF_0		0xe4
+#define	G_OBJ_RECTANGLE		0x01
+#define	G_OBJ_SPRITE		0x02
+#define	G_SELECT_DL		0x04
+#define	G_OBJ_LOADTXTR		0x05
+#define	G_OBJ_LDTX_SPRITE	0x06
+#define	G_OBJ_LDTX_RECT		0x07
+#define	G_OBJ_LDTX_RECT_R	0x08
+#define	G_BG_1CYC		0x09
+#define	G_BG_COPY		0x0a
+#define	G_OBJ_RENDERMODE	0x0b
+#else
 #define	G_BG_1CYC		0x01
 #define	G_BG_COPY		0x02
 #define	G_OBJ_RECTANGLE		0x03
@@ -244,7 +258,7 @@ typedef	struct	{
 #define	G_OBJ_LDTX_RECT		0xc3
 #define	G_OBJ_LDTX_RECT_R	0xc4
 #define	G_RDPHALF_0		0xe4
-
+#endif
 
 /*---------------------------------------------------------------------------*
  *	Background wrapped screen
@@ -305,7 +319,7 @@ typedef	struct	{
 /*---------------------------------------------------------------------------*
  *	Set general status
  *---------------------------------------------------------------------------*/
-#define	G_MW_GENSTAT	0x08	/* Note that it is the same value of G_MW_FOG.  */
+#define	G_MW_GENSTAT	0x08	/* Note that it is the same value of G_MW_FOG */
 
 #define	gSPSetStatus(pkt, sid, val)	\
 	gMoveWd((pkt), G_MW_GENSTAT, (sid), (val))
@@ -352,9 +366,21 @@ extern	u64	gspS2DEX_fifoTextStart[], gspS2DEX_fifoTextEnd[];
 extern	u64	gspS2DEX_fifoDataStart[], gspS2DEX_fifoDataEnd[];
 extern	u64	gspS2DEX_fifo_dTextStart[], gspS2DEX_fifo_dTextEnd[];
 extern	u64	gspS2DEX_fifo_dDataStart[], gspS2DEX_fifo_dDataEnd[];
+extern	u64	gspS2DEX2_fifoTextStart[], gspS2DEX2_fifoTextEnd[];
+extern	u64	gspS2DEX2_fifoDataStart[], gspS2DEX2_fifoDataEnd[];
+extern	u64	gspS2DEX2_xbusTextStart[], gspS2DEX2_xbusTextEnd[];
+extern	u64	gspS2DEX2_xbusDataStart[], gspS2DEX2_xbusDataEnd[];
 extern	void	guS2DInitBg(uObjBg *);
-extern	void	guS2DEmuSetScissor(u32, u32, u32, u32, u8);
-extern	void	guS2DEmuBgRect1Cyc(Gfx **, uObjBg *);
+
+#ifdef	F3DEX_GBI_2
+# define guS2DEmuBgRect1Cyc	guS2D2EmuBgRect1Cyc	/*Wrapper*/
+# define guS2DEmuSetScissor	guS2D2EmuSetScissor	/*Wrapper*/
+  extern void	guS2D2EmuSetScissor(u32, u32, u32, u32, u8);
+  extern void	guS2D2EmuBgRect1Cyc(Gfx **, uObjBg *);
+#else
+  extern void	guS2DEmuSetScissor(u32, u32, u32, u32, u8);
+  extern void	guS2DEmuBgRect1Cyc(Gfx **, uObjBg *);
+#endif
 
 #ifdef _LANGUAGE_C_PLUS_PLUS
 }

--- a/include/PR/sptask.h
+++ b/include/PR/sptask.h
@@ -12,8 +12,8 @@
 
 /**************************************************************************
  *
- *  $Revision: 1.8 $
- *  $Date: 1997/11/10 10:48:35 $
+ *  $Revision: 1.9 $
+ *  $Date: 1998/03/05 06:40:29 $
  *  $Source: /hosts/liberte/disk6/Master/cvsmdev2/PR/include/sptask.h,v $
  *
  **************************************************************************/
@@ -137,7 +137,7 @@ typedef u32 OSYieldResult;
  * boundary.  The taskHdrPtr->t.yield_data_ptr must be set to point to the
  * buffer BEFORE the task is started.
  */
-#if	(defined(F3DEX_GBI)||defined(F3DLP_GBI))
+#if	(defined(F3DEX_GBI)||defined(F3DLP_GBI)||defined(F3DEX_GBI_2))
 #define	OS_YIELD_DATA_SIZE		0xc00
 #else
 #define OS_YIELD_DATA_SIZE		0x900

--- a/include/PR/ucode.h
+++ b/include/PR/ucode.h
@@ -12,8 +12,8 @@
 
 /**************************************************************************
  *
- *  $Revision: 1.13 $
- *  $Date: 1997/11/07 04:55:12 $
+ *  $Revision: 1.15 $
+ *  $Date: 1998/03/31 07:58:57 $
  *  $Source: /hosts/liberte/disk6/Master/cvsmdev2/PR/include/ucode.h,v $
  *
  **************************************************************************/
@@ -153,23 +153,29 @@ extern long long int  gspL3DEX_fifoTextStart[],     gspL3DEX_fifoTextEnd[];
 extern long long int  gspL3DEX_fifoDataStart[],     gspL3DEX_fifoDataEnd[];
 
 /*========== F3DEX2/F3DLX2/F3DLP2/L3DEX2 ==========*/
-/* FIFO version only */
+/* FIFO version */
 extern long long int gspF3DEX2_fifoTextStart[],    gspF3DEX2_fifoTextEnd[];
 extern long long int gspF3DEX2_fifoDataStart[],    gspF3DEX2_fifoDataEnd[];
 extern long long int gspF3DEX2_NoN_fifoTextStart[],gspF3DEX2_NoN_fifoTextEnd[];
 extern long long int gspF3DEX2_NoN_fifoDataStart[],gspF3DEX2_NoN_fifoDataEnd[];
-
-extern long long int gspF3DLX2_fifoTextStart[],    gspF3DLX2_fifoTextEnd[];
-extern long long int gspF3DLX2_fifoDataStart[],    gspF3DLX2_fifoDataEnd[];
-extern long long int gspF3DLX2_NoN_fifoTextStart[],gspF3DLX2_NoN_fifoTextEnd[];
-extern long long int gspF3DLX2_NoN_fifoDataStart[],gspF3DLX2_NoN_fifoDataEnd[];
+extern long long int gspF3DEX2_Rej_fifoTextStart[],gspF3DEX2_Rej_fifoTextEnd[];
+extern long long int gspF3DEX2_Rej_fifoDataStart[],gspF3DEX2_Rej_fifoDataEnd[];
 extern long long int gspF3DLX2_Rej_fifoTextStart[],gspF3DLX2_Rej_fifoTextEnd[];
 extern long long int gspF3DLX2_Rej_fifoDataStart[],gspF3DLX2_Rej_fifoDataEnd[];
-
-extern long long int gspF3DLP2_Rej_fifoTextStart[],gspF3DLP2_Rej_fifoTextEnd[];
-extern long long int gspF3DLP2_Rej_fifoDataStart[],gspF3DLP2_Rej_fifoDataEnd[];
 extern long long int gspL3DEX2_fifoTextStart[],    gspL3DEX2_fifoTextEnd[];
 extern long long int gspL3DEX2_fifoDataStart[],    gspL3DEX2_fifoDataEnd[];
+
+/* XBUS version */
+extern long long int gspF3DEX2_xbusTextStart[],    gspF3DEX2_xbusTextEnd[];
+extern long long int gspF3DEX2_xbusDataStart[],    gspF3DEX2_xbusDataEnd[];
+extern long long int gspF3DEX2_NoN_xbusTextStart[],gspF3DEX2_NoN_xbusTextEnd[];
+extern long long int gspF3DEX2_NoN_xbusDataStart[],gspF3DEX2_NoN_xbusDataEnd[];
+extern long long int gspF3DEX2_Rej_xbusTextStart[],gspF3DEX2_Rej_xbusTextEnd[];
+extern long long int gspF3DEX2_Rej_xbusDataStart[],gspF3DEX2_Rej_xbusDataEnd[];
+extern long long int gspF3DLX2_Rej_xbusTextStart[],gspF3DLX2_Rej_xbusTextEnd[];
+extern long long int gspF3DLX2_Rej_xbusDataStart[],gspF3DLX2_Rej_xbusDataEnd[];
+extern long long int gspL3DEX2_xbusTextStart[],    gspL3DEX2_xbusTextEnd[];
+extern long long int gspL3DEX2_xbusDataStart[],    gspL3DEX2_xbusDataEnd[];
 
 /**************************************************************************
  *


### PR DESCRIPTION
We were using the vanilla 2.0I version of libultra.
However this does not include the F3DEX2 patch that MP1 uses.

- Replace headers associated with 9801 patch